### PR TITLE
Locks implementados con fcntl

### DIFF
--- a/BlockingSharedQueue.cpp
+++ b/BlockingSharedQueue.cpp
@@ -36,21 +36,21 @@ key_t BlockingSharedQueue::get_segment_key(unsigned int queue_id) {
   this->queue_path = path_builder.str();
 
   // Intentamos abrir el archivo, o lo creamos si no existe.
-  this->fd = open(this->queue_path.c_str(), O_CREAT, 0644);
+  this->fd = open(this->queue_path.c_str(), O_CREAT|O_RDWR, 0644);
 
   // Generamos y retornamos la clave usada para instanciar el segmento.
   return ftok(this->queue_path.c_str(), 1);
 }
 
 int BlockingSharedQueue::enqueue(void *data, uint32_t data_size, uint16_t p) {
-  Lock(this->fd);
+  Lock(this->queue_path);
 
   // Acolamos el nuevo elemento en la estructura.
   this->queue->enqueue(data, data_size, p);
 }
 
 unsigned int BlockingSharedQueue::take(unsigned int n, std::list<void *> &l) {
-  Lock(this->fd);
+  Lock(this->queue_path);
 
   // Determinamos cantidad de elementos a leer.
   uint16_t c = this->queue->count();
@@ -66,7 +66,7 @@ unsigned int BlockingSharedQueue::take(unsigned int n, std::list<void *> &l) {
 }
 
 unsigned int BlockingSharedQueue::count() {
-  Lock(this->fd);
+  Lock(this->queue_path);
   return this->queue->count();
 }
 

--- a/City.cpp
+++ b/City.cpp
@@ -68,7 +68,9 @@ void City::push_new_person() {
 }
 
 void City::receive_boat(Boat &boat) {
-  Lock(this->fd);
+
+  LOG(LOG_DEBUG, "[" + std::to_string(getpid()) + "] Attempting to set lock with file descriptor: " + std::to_string(fd));
+  Lock(this->lock_path);
 
   LOG(LOG_INFO, "Bote " << boat.get_pid() << " llega a ciudad " << this->id);
 

--- a/HDuplexChannel.cpp
+++ b/HDuplexChannel.cpp
@@ -1,5 +1,6 @@
 #include "HDuplexChannel.h"
 #include "Lock.h"
+#include "Logger.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -42,7 +43,9 @@ int HDuplexChannel::push(void *data, ssize_t count) {
 }
 
 void HDuplexChannel::recv(void *buff, ssize_t count) {
-  Lock(this->fd);
+
+  LOG(LOG_DEBUG, "[" + std::to_string(getpid()) + ", HDuplex] Attempting to set lock with file descriptor: " + std::to_string(fd));
+  Lock(this->path);
 
   ssize_t r = 0;
   while (r < count) {
@@ -51,7 +54,9 @@ void HDuplexChannel::recv(void *buff, ssize_t count) {
 }
 
 ssize_t HDuplexChannel::recv_or_continue(void *buff, ssize_t count) {
-  Lock(this->fd);
+
+  LOG(LOG_DEBUG, "[" + std::to_string(getpid()) + "] Attempting to set lock with file descriptor: " + std::to_string(fd));
+  Lock(this->path);
 
   // Obtenemos los flags asociados al descriptor, sin nonblock.
   int flags = fcntl(this->fd, F_GETFL) & (~O_NONBLOCK);

--- a/Lock.cpp
+++ b/Lock.cpp
@@ -1,16 +1,45 @@
 #include "Lock.h"
 
 #include <sys/file.h>
+#include <unistd.h>
+#include "Logger.h"
+#include <string.h>
+#include <errno.h>
 
-Lock::Lock(int fd) {
-  // TODO: Verificar que el file descriptor sea válido.
+Lock::Lock(std::string name) {
+  this->name = name + ".lock";
+  this->lock.l_len = 0;
+  this->lock.l_start = 0;
+  this->lock.l_whence = SEEK_SET;
 
-  this->fd = fd;
+  this->fd = open(this->name.c_str(), O_CREAT|O_WRONLY, 0777);
+  if (fd < 0) {
+    LOG(LOG_ERROR, "Error tratando de crear archivo de lock " + this->name);
+    exit(0);
+  }
+  std::string message = "Intento de tomar lock";
+  LOG(LOG_INFO, message)
 
-  // Bloqueamos el archivo; el lock durará mientras exista el objeto.
-  flock(fd, LOCK_EX);
+  this->lock.l_type = F_WRLCK;
+
+  // Intento de tomar lock sobre el archivo .lock
+  if (fcntl(this->fd, F_SETLKW, &(this->lock)) < 0) {
+    LOG(LOG_ERROR, "Error tomando lock, errno: " + std::to_string(errno));
+    exit(0);
+  }
 }
 
 Lock::~Lock() {
-  flock(this->fd, LOCK_UN);
+
+  // Intento de liberar el lock sobre el archivo .lock
+  this->lock.l_type = F_UNLCK;
+  std::string message = "Intentando liberar lock";
+  LOG(LOG_INFO, message)
+  if (fcntl(this->fd, F_SETLKW, &(this->lock)) < 0) {
+    LOG(LOG_ERROR, "Error liberando lock, errno: " + std::to_string(errno));
+    exit(0);
+  }
+
+  // Cierre del archivo
+  close(this->fd);
 }

--- a/Lock.h
+++ b/Lock.h
@@ -1,19 +1,22 @@
 #ifndef LOCK_H_
 #define LOCK_H_
-
+#include <fcntl.h>
+#include <string>
 class Lock {
 
 private:
 
   int fd;
+  struct flock lock;
+  std::string name;
 
 public:
 
   /*
-   * Toma un lock exclusivo sobre el archivo indicado por el descriptor fd.
+   * Toma un lock exclusivo sobre el archivo indicado por el pathname name + ".lock"
    * El lock permanecerá tomado mientras exista el objeto Lock.
    */
-  Lock(int fd);
+  Lock(std::string name);
 
   /*
    * Desbloquea el archivo.


### PR DESCRIPTION
Cambié la lógica de cómo se settean. No sólo para que no use ´flock´, si no que no se use el file descriptor del archivo de la ´BlockedSharedQueue´ para el lock (estaba creando problemas al tratar de settear el lock) si no crear otro archivo que se llame igual que el archivo que invoca al lock pero con ".lock" al final. Por eso ahora el constructor recibe un string de parámetro ´Lock(string name)´